### PR TITLE
Fix voltammetry_CV doc

### DIFF
--- a/docs/source/generated_voltammetry/voltammetry.rst
+++ b/docs/source/generated_voltammetry/voltammetry.rst
@@ -31,7 +31,7 @@ voltammetry.voltammetry\_CP
 voltammetry.voltammetry\_CV
 -------------------------------
 
-.. automodule:: voltammetry.voltammetry_CP
+.. automodule:: voltammetry.voltammetry_CV
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
This PR fixes the generation of the documentation for the Voltammetry_CV class that was showing the doc for Voltammetry_CP.